### PR TITLE
Add joint state publisher and periodic polling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(rclpy REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 set(msg_files
 	"msg/ACFTelem.msg"

--- a/README.md
+++ b/README.md
@@ -51,3 +51,33 @@ To run the acf interface with an ACF with a non-default ip address:
 ```bash
 ros2 run ferrobotics_acf acf.py --ros-args -p ip:=192.168.123.132
 ```
+
+### Parameters
+
+The `acf.py` executable exposes the following parameters:
+
+- `ip` -> the acf ip address
+- `f_max` -> the maximum allowed force [N]
+- `initial_force` -> the force generated when no contact is detected [N]
+- `ramp_duration` -> the ramp time of the force once contact is detected [s]
+- `payload` -> the mass attached to the acf [kg]
+
+### Services
+
+The `ACF` node creates the following services:
+
+- `/ACF/set_payload` (SetFloat) -> used to set the current payload [kg]
+- `/ACF/set_f_zero` (SetFloat) -> used to set force generated when no contact is detected [N]
+- `/ACF/set_t_ramp` (SetDuration) -> used to set the ramp time of the force once contact is detected [s]
+
+### Publishers
+
+The `ACF` node publishes on the following topic:
+
+- `/ACF/telem` (ACFTelem) -> Contains return information from the ACF. Only published after receiving a force command.
+
+### Subscribers
+
+The `ACF` node subscribes to the following topic:
+
+- `/ACF/force` (Float32) -> Used to set the current output force of the ACF in Newtons. Telemetry information is sent after receiving a force command.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ The `ACF` node creates the following services:
 
 The `ACF` node publishes on the following topic:
 
-- `/ACF/telem` (`ACFTelem`) -> Contains return information from the ACF. Only published after receiving a force command.
+- `/ACF/telem` (`ACFTelem`) -> Contains return information from the ACF. Only published (shortly) after receiving a message on `/ACF/force` or when polling is active.
 - `/joint_state` (`JointState`) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
 
 ### Subscribers
 
 The `ACF` node subscribes to the following topic:
 
-- `/ACF/force` (`Float32`) -> Used to set the current output force of the ACF in Newtons. Telemetry information is sent after receiving a force command.
+- `/ACF/force` (`Float32`) -> Used to set the current output force of the ACF in Newtons.

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ This node will also act as a joint state publisher when the `joint_name` paramet
 
 The `ACF` node creates the following services:
 
-- `/ACF/set_payload` (`SetFloat`) -> used to set the current payload [kg]
-- `/ACF/set_f_zero` (`SetFloat`) -> used to set force generated when no contact is detected [N]
-- `/ACF/set_t_ramp` (`SetDuration`) -> used to set the ramp time of the force once contact is detected [s]
+- `set_payload` (`SetFloat`) -> used to set the current payload [kg]
+- `set_f_zero` (`SetFloat`) -> used to set force generated when no contact is detected [N]
+- `set_t_ramp` (`SetDuration`) -> used to set the ramp time of the force once contact is detected [s]
 
 ### Publishers
 
 The `ACF` node publishes on the following topic:
 
-- `/ACF/telem` (`ACFTelem`) -> Contains return information from the ACF. Only published (shortly) after receiving a message on `/ACF/force` or when polling is active.
-- `/joint_state` (`JointState`) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
+- `telem` (`ACFTelem`) -> Contains return information from the ACF. Only published (shortly) after receiving a message on `/ACF/force` or when polling is active.
+- `joint_state` (`JointState`) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
 
 ### Subscribers
 
 The `ACF` node subscribes to the following topic:
 
-- `/ACF/force` (`Float32`) -> Used to set the current output force of the ACF in Newtons.
+- `force` (`Float32`) -> Used to set the current output force of the ACF in Newtons.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ ros2 run ferrobotics_acf acf.py --ros-args -p ip:=192.168.123.132
 
 The `acf.py` executable exposes the following parameters:
 
-- `ip` -> the acf ip address
-- `f_max` -> the maximum allowed force [N]
-- `initial_force` -> the force generated when no contact is detected [N]
-- `ramp_duration` -> the ramp time of the force once contact is detected [s]
-- `payload` -> the mass attached to the acf [kg]
-- `frequency` -> the polling frequency [Hz]
-- `joint_name` -> the ACF joint name
+- `ip` -> the acf ip address (string)
+- `f_max` -> the maximum allowed force [N] (integer)
+- `initial_force` -> the force generated when no contact is detected [N] (double)
+- `ramp_duration` -> the ramp time of the force once contact is detected [s] (double)
+- `payload` -> the mass attached to the acf [kg] (double)
+- `frequency` -> the polling frequency [Hz] (integer)
+- `joint_name` -> the ACF joint name (string)
 
 ### Polling mode
 
@@ -78,19 +78,19 @@ This node will also act as a joint state publisher when the `joint_name` paramet
 
 The `ACF` node creates the following services:
 
-- `/ACF/set_payload` (SetFloat) -> used to set the current payload [kg]
-- `/ACF/set_f_zero` (SetFloat) -> used to set force generated when no contact is detected [N]
-- `/ACF/set_t_ramp` (SetDuration) -> used to set the ramp time of the force once contact is detected [s]
+- `/ACF/set_payload` (`SetFloat`) -> used to set the current payload [kg]
+- `/ACF/set_f_zero` (`SetFloat`) -> used to set force generated when no contact is detected [N]
+- `/ACF/set_t_ramp` (`SetDuration`) -> used to set the ramp time of the force once contact is detected [s]
 
 ### Publishers
 
 The `ACF` node publishes on the following topic:
 
-- `/ACF/telem` (ACFTelem) -> Contains return information from the ACF. Only published after receiving a force command.
-- `/joint_state` (JointState) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
+- `/ACF/telem` (`ACFTelem`) -> Contains return information from the ACF. Only published after receiving a force command.
+- `/joint_state` (`JointState`) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
 
 ### Subscribers
 
 The `ACF` node subscribes to the following topic:
 
-- `/ACF/force` (Float32) -> Used to set the current output force of the ACF in Newtons. Telemetry information is sent after receiving a force command.
+- `/ACF/force` (`Float32`) -> Used to set the current output force of the ACF in Newtons. Telemetry information is sent after receiving a force command.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ The `acf.py` executable exposes the following parameters:
 - `initial_force` -> the force generated when no contact is detected [N]
 - `ramp_duration` -> the ramp time of the force once contact is detected [s]
 - `payload` -> the mass attached to the acf [kg]
+- `frequency` -> the polling frequency [Hz]
+- `joint_name` -> the ACF joint name
+
+### Polling mode
+
+If the `frequency` parameter is set, commands will be set to the ACF at that rate. Received force commands will not immediately trigger sending of commands to the ACF in this mode. ACF telemetry will be received at the same rate.
+
+If the parameter is set to zero, commands will only be sent to the ACF when a force command is received. Telemetry is only sent after each force command.
+
+### Joint State Publisher
+
+This node will also act as a joint state publisher when the `joint_name` parameter is set. This may be useful in conjunction with a robot state publisher.
 
 ### Services
 
@@ -75,6 +87,7 @@ The `ACF` node creates the following services:
 The `ACF` node publishes on the following topic:
 
 - `/ACF/telem` (ACFTelem) -> Contains return information from the ACF. Only published after receiving a force command.
+- `/joint_state` (JointState) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
 
 ### Subscribers
 

--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ This node will also act as a joint state publisher when the `joint_name` paramet
 
 ### Services
 
-The `ACF` node creates the following services:
+The `acf` node creates the following services:
 
-- `set_payload` (`SetFloat`) -> used to set the current payload [kg]
-- `set_f_zero` (`SetFloat`) -> used to set force generated when no contact is detected [N]
-- `set_t_ramp` (`SetDuration`) -> used to set the ramp time of the force once contact is detected [s]
+- `~/set_payload` (`SetFloat`) -> used to set the current payload [kg]
+- `~/set_f_zero` (`SetFloat`) -> used to set force generated when no contact is detected [N]
+- `~/set_t_ramp` (`SetDuration`) -> used to set the ramp time of the force once contact is detected [s]
 
 ### Publishers
 
-The `ACF` node publishes on the following topic:
+The `acf` node publishes on the following topic:
 
-- `telem` (`ACFTelem`) -> Contains return information from the ACF. Only published (shortly) after receiving a message on `/ACF/force` or when polling is active.
+- `~/telem` (`ACFTelem`) -> Contains return information from the ACF. Only published (shortly) after receiving a message on `/ACF/force` or when polling is active.
 - `joint_state` (`JointState`) -> Publishes the current position of the ACF as a joint state. Only published if the `joint_name` parameter is set.
 
 ### Subscribers
 
-The `ACF` node subscribes to the following topic:
+The `acf` node subscribes to the following topic:
 
-- `force` (`Float32`) -> Used to set the current output force of the ACF in Newtons.
+- `~/force` (`Float32`) -> Used to set the current output force of the ACF in Newtons.

--- a/package.xml
+++ b/package.xml
@@ -22,4 +22,5 @@
 
  <depend>rclpy</depend>
  <depend>builtin_interfaces</depend>
+ <depend>sensor_msgs</depend>
 </package>

--- a/src/acf.py
+++ b/src/acf.py
@@ -203,15 +203,15 @@ class FerroboticsACF(Node):
         return response
 
     def ros_setup(self):
-        self.create_subscription(Float32, '/ACF/force', self.command_handler, 10)
-        self.telem_pub = self.create_publisher(ACFTelem, '/ACF/telem', 5)
-        self.create_service(SetFloat, '/ACF/set_payload', self.set_payload)
-        self.create_service(SetFloat, '/ACF/set_f_zero', self.set_f_zero)
-        self.create_service(SetDuration, '/ACF/set_t_ramp', self.set_t_ramp)
+        self.create_subscription(Float32, 'force', self.command_handler, 10)
+        self.telem_pub = self.create_publisher(ACFTelem, 'telem', 5)
+        self.create_service(SetFloat, 'set_payload', self.set_payload)
+        self.create_service(SetFloat, 'set_f_zero', self.set_f_zero)
+        self.create_service(SetDuration, 'set_t_ramp', self.set_t_ramp)
         if self.frequency > 0:
             self.create_timer(1 / self.frequency, self.timer_callback)
         if self.joint_name != "":
-            self.joint_state_pub = self.create_publisher(JointState, '/joint_states', 10)
+            self.joint_state_pub = self.create_publisher(JointState, 'joint_states', 10)
         else:
             self.joint_state_pub = None
 

--- a/src/acf.py
+++ b/src/acf.py
@@ -138,9 +138,9 @@ class FerroboticsACF(Node):
             msg.header.stamp = self.get_clock().now().to_msg()
             msg.header.frame_id = f"{self.i}"
             msg.name = [self.joint_name]
-            msg.position = [telem.position/1000]
-            msg.velocity = [0.0]    # TODO Calculate this by finite difference
-            msg.effort = [0.0]      # TODO Send the current force at the joint
+            msg.position = [telem.position / 1e3] # Convert from mm to m
+            # msg.velocity = [] # TODO Calculate this by finite difference
+            # msg.effort = [] # TODO Send the current force at the joint
             self.joint_state_pub.publish(msg)
         self.i += 1
 
@@ -192,7 +192,7 @@ class FerroboticsACF(Node):
         return response
 
     def set_t_ramp(self, request : SetDuration.Request, response : SetDuration.Response):
-        duration = request.duration.sec + (request.duration.nanosec / 1000000000.0)
+        duration = request.duration.sec + (request.duration.nanosec / 1e9)
         if not self.check_ramp_duration(duration):
             response.success = False
             response.message = "Invalid duration."
@@ -209,7 +209,7 @@ class FerroboticsACF(Node):
         self.create_service(SetFloat, 'set_f_zero', self.set_f_zero)
         self.create_service(SetDuration, 'set_t_ramp', self.set_t_ramp)
         if self.frequency > 0:
-            self.create_timer(1 / self.frequency, self.timer_callback)
+            self.create_timer(1.0 / self.frequency, self.timer_callback)
         if self.joint_name != "":
             self.joint_state_pub = self.create_publisher(JointState, 'joint_states', 10)
         else:

--- a/src/acf.py
+++ b/src/acf.py
@@ -145,9 +145,8 @@ class FerroboticsACF(Node):
         self.i += 1
 
     def command_handler(self, msg):
-        if self.frequency > 0:
-            self.force = msg.data
-        else:
+        self.force = msg.data
+        if self.frequency <= 0:
             self.timer_callback()
 
     def handle_telem(self) -> ACFTelem:

--- a/src/acf.py
+++ b/src/acf.py
@@ -43,7 +43,7 @@ class FerroboticsACF(Node):
     ]
 
     def __init__(self):
-        super().__init__('ACF')
+        super().__init__('acf')
         self.get_params()
         self.connect()
         assert self.authenticate(), "Failed to authenticate"
@@ -200,11 +200,11 @@ class FerroboticsACF(Node):
         return response
 
     def ros_setup(self):
-        self.create_subscription(Float32, 'force', self.command_handler, 10)
-        self.telem_pub = self.create_publisher(ACFTelem, 'telem', 5)
-        self.create_service(SetFloat, 'set_payload', self.set_payload)
-        self.create_service(SetFloat, 'set_f_zero', self.set_f_zero)
-        self.create_service(SetDuration, 'set_t_ramp', self.set_t_ramp)
+        self.create_subscription(Float32, '~/force', self.command_handler, 10)
+        self.telem_pub = self.create_publisher(ACFTelem, '~/telem', 5)
+        self.create_service(SetFloat, '~/set_payload', self.set_payload)
+        self.create_service(SetFloat, '~/set_f_zero', self.set_f_zero)
+        self.create_service(SetDuration, '~/set_t_ramp', self.set_t_ramp)
         if self.frequency > 0:
             self.create_timer(1.0 / self.frequency, self.timer_callback)
         if self.joint_name != "":

--- a/src/acf.py
+++ b/src/acf.py
@@ -76,7 +76,6 @@ class FerroboticsACF(Node):
         self.frequency = self.get_parameter('frequency').get_parameter_value().integer_value
         self.joint_name = self.get_parameter('joint_name').get_parameter_value().string_value
         self.force = 0
-        self.i = 0
 
     def check_force(self, force):
         return -self.f_max <= force <= self.f_max
@@ -136,13 +135,11 @@ class FerroboticsACF(Node):
         if self.joint_state_pub is not None:
             msg = JointState()
             msg.header.stamp = self.get_clock().now().to_msg()
-            msg.header.frame_id = f"{self.i}"
             msg.name = [self.joint_name]
             msg.position = [telem.position / 1e3] # Convert from mm to m
             # msg.velocity = [] # TODO Calculate this by finite difference
             # msg.effort = [] # TODO Send the current force at the joint
             self.joint_state_pub.publish(msg)
-        self.i += 1
 
     def command_handler(self, msg):
         self.force = msg.data


### PR DESCRIPTION
Added two complementary features to code:

#### Periodic Polling
Allows for the ACF telemetry to be published at a fixed frequency without requiring constant publishing on `/ACF/force`. Can be deactivated (by setting the frequency parameter to zero) to yield the old behavior.

#### Joint State Publisher
The latest position of the ACF can be published as a joint state, for simple integration with robot state publishers. This feature is best used in conjunction with periodic polling to give frequent joint state updates.

#### Reverse compatibility
When running the package without setting the new parameters (frequency and joint_name), behaviour is unaltered from before.

Tested and works on an ACF/111/04.

