### PR TITLE
ACFTelemStamped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,9 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,11 @@ find_package(builtin_interfaces REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 set(msg_files
 	"msg/ACFTelem.msg"
+	"msg/ACFTelemStamped.msg"
 )
 
 set(srv_files
@@ -24,6 +26,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 	${msg_files}
 	${srv_files}
 	DEPENDENCIES builtin_interfaces
+	DEPENDENCIES std_msgs
 )
 
 install(PROGRAMS

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone the correct version for **Humble** from this repository inside your worksp
 
 ```bash
 cd ros2_ws/src
-git clone https://github.com/thettasch/ferrobotics_acf.git -b humble
+git clone https://github.com/Luka140/ferrobotics_acf.git -b humble
 cd ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone the correct version for **Humble** from this repository inside your worksp
 
 ```bash
 cd ros2_ws/src
-git clone https://github.com/Luka140/ferrobotics_acf.git -b humble
+git clone https://github.com/sam-xl/ferrobotics_acf.git -b humble
 cd ..
 ```
 

--- a/launch/acf.launch.py
+++ b/launch/acf.launch.py
@@ -1,0 +1,35 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch.actions
+import datetime
+import pathlib
+from itertools import product
+import numpy as np 
+
+import os
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    ld = LaunchDescription()
+
+    
+    acf_node = Node(
+        package='ferrobotics_acf',
+        executable='acf.py',
+        parameters=[
+            {'ip': '169.254.200.17',
+             'ramp_duration': 0.,
+             'frequency':120,
+             'payload': 0.0,
+            }
+        ]
+    )
+
+    ld.add_action(acf_node)
+    return ld

--- a/msg/ACFTelemStamped.msg
+++ b/msg/ACFTelemStamped.msg
@@ -1,0 +1,2 @@
+ferrobotics_acf/ACFTelem telemetry
+std_msgs/Header header 

--- a/src/acf.py
+++ b/src/acf.py
@@ -2,6 +2,7 @@
 
 import rclpy
 from rclpy.node import Node
+from rclpy.executors import MultiThreadedExecutor
 
 # Import messages and services
 from std_msgs.msg import Float32
@@ -19,7 +20,7 @@ if sys.version_info.major >= 3:
 
 
 class FerroboticsACF(Node):
-    DEFAULT_IP = "192.168.99.1"
+    DEFAULT_IP = "169.254.200.17"
     DEFAULT_PORT = 7070
     DEFAULT_AUTHENTICATION = "ferba"
     DEFAULT_ID = 1040
@@ -220,6 +221,14 @@ class FerroboticsACF(Node):
 if __name__ == "__main__":
     rclpy.init()
     acf_node = FerroboticsACF()
-    rclpy.spin(acf_node)
+    try:
+        rclpy.spin(acf_node, executor=MultiThreadedExecutor())
+    except KeyboardInterrupt:
+        pass 
     acf_node.destroy_node()
-    rclpy.shutdown()
+    
+    # Avoid stack trace 
+    try:
+        rclpy.shutdown()
+    except rclpy._rclpy_pybind11.RCLError:
+        pass 


### PR DESCRIPTION
This adds a Stamped version of the ACFTelem message type and a launch file. 

## Motivation
- The usage of ACFTelem was changed to ACFTelemStamped because the data was recorded with rosbags, after which the time-series was analyzed. Using the timestamp received from the ACF interface is more robust and accurate than using the publication time of the message. 
- The launch file was added to simplify testing different launch parameters 

## Changes
- Adds ACFTelemStamped message type
- Changes the use of ACFTelem to ACFTelemStamped in `acf.py` 
- Adds simple launch file